### PR TITLE
Add shape transform controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,23 @@
 <style>
   html, body { height: 100%; margin: 0; }
   #map { width: 100%; height: 100%; }
+  #controls { position: absolute; top: 10px; left: 10px; background: white; padding: 4px; z-index: 1000; }
+  #controls button { margin: 2px; }
 </style>
 </head>
 <body>
 <div id="map"></div>
+<div id="controls">
+  <button id="up">Up</button>
+  <button id="down">Down</button>
+  <button id="left">Left</button>
+  <button id="right">Right</button>
+  <button id="rotLeft">Rotate -</button>
+  <button id="rotRight">Rotate +</button>
+  <button id="scaleDown">Scale -</button>
+  <button id="scaleUp">Scale +</button>
+  <button id="save">Save</button>
+</div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -7,9 +7,9 @@ const map = L.map('map', {
 L.imageOverlay('map.png', bounds).addTo(map);
 map.fitBounds(bounds);
 
-const MOVE_STEP = 2;
-const ROTATE_STEP = 1;
-const SCALE_STEP = 0.05; // 5%
+const MOVE_STEP = 0.2;
+const ROTATE_STEP = 0.1;
+const SCALE_STEP = 0.01; // 1%
 
 let geojsonData = null;
 let geoLayer = null;

--- a/script.js
+++ b/script.js
@@ -7,6 +7,10 @@ const map = L.map('map', {
 L.imageOverlay('map.png', bounds).addTo(map);
 map.fitBounds(bounds);
 
+const MOVE_STEP = 2;
+const ROTATE_STEP = 1;
+const SCALE_STEP = 0.05; // 5%
+
 let geojsonData = null;
 let geoLayer = null;
 
@@ -102,12 +106,12 @@ fetch('shapes.geojson')
     draw();
   });
 
-document.getElementById('up').addEventListener('click', () => translate(0, -10));
-document.getElementById('down').addEventListener('click', () => translate(0, 10));
-document.getElementById('left').addEventListener('click', () => translate(-10, 0));
-document.getElementById('right').addEventListener('click', () => translate(10, 0));
-document.getElementById('rotLeft').addEventListener('click', () => rotate(-5));
-document.getElementById('rotRight').addEventListener('click', () => rotate(5));
-document.getElementById('scaleDown').addEventListener('click', () => scale(0.9));
-document.getElementById('scaleUp').addEventListener('click', () => scale(1.1));
+document.getElementById('up').addEventListener('click', () => translate(0, -MOVE_STEP));
+document.getElementById('down').addEventListener('click', () => translate(0, MOVE_STEP));
+document.getElementById('left').addEventListener('click', () => translate(-MOVE_STEP, 0));
+document.getElementById('right').addEventListener('click', () => translate(MOVE_STEP, 0));
+document.getElementById('rotLeft').addEventListener('click', () => rotate(-ROTATE_STEP));
+document.getElementById('rotRight').addEventListener('click', () => rotate(ROTATE_STEP));
+document.getElementById('scaleDown').addEventListener('click', () => scale(1 - SCALE_STEP));
+document.getElementById('scaleUp').addEventListener('click', () => scale(1 + SCALE_STEP));
 document.getElementById('save').addEventListener('click', download);

--- a/script.js
+++ b/script.js
@@ -7,19 +7,107 @@ const map = L.map('map', {
 L.imageOverlay('map.png', bounds).addTo(map);
 map.fitBounds(bounds);
 
+let geojsonData = null;
+let geoLayer = null;
+
+function draw() {
+  if (geoLayer) map.removeLayer(geoLayer);
+  geoLayer = L.geoJSON(geojsonData, {
+    style: {
+      color: '#ff7800',
+      weight: 1,
+      fillOpacity: 0.5
+    },
+    onEachFeature: function(feature, layer) {
+      let props = feature.properties;
+      let content = Object.keys(props).map(k => `<strong>${k}:</strong> ${props[k]}`).join('<br>');
+      layer.bindPopup(content);
+    }
+  }).addTo(map);
+}
+
+function forEachCoord(geometry, cb) {
+  if (geometry.type === 'Polygon') {
+    geometry.coordinates.forEach(ring => ring.forEach(pt => cb(pt)));
+  } else if (geometry.type === 'MultiPolygon') {
+    geometry.coordinates.forEach(poly => poly.forEach(ring => ring.forEach(pt => cb(pt))));
+  }
+}
+
+function transformCoords(geometry, fn) {
+  if (geometry.type === 'Polygon') {
+    geometry.coordinates = geometry.coordinates.map(ring => ring.map(fn));
+  } else if (geometry.type === 'MultiPolygon') {
+    geometry.coordinates = geometry.coordinates.map(poly => poly.map(ring => ring.map(fn)));
+  }
+}
+
+function getCenter(data) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  data.features.forEach(f => {
+    forEachCoord(f.geometry, pt => {
+      const [x, y] = pt;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    });
+  });
+  return [(minX + maxX) / 2, (minY + maxY) / 2];
+}
+
+function translate(dx, dy) {
+  geojsonData.features.forEach(f => {
+    transformCoords(f.geometry, ([x, y]) => [x + dx, y + dy]);
+  });
+  draw();
+}
+
+function rotate(angle) {
+  const [cx, cy] = getCenter(geojsonData);
+  const rad = angle * Math.PI / 180;
+  const cos = Math.cos(rad), sin = Math.sin(rad);
+  geojsonData.features.forEach(f => {
+    transformCoords(f.geometry, ([x, y]) => {
+      const nx = cos * (x - cx) - sin * (y - cy) + cx;
+      const ny = sin * (x - cx) + cos * (y - cy) + cy;
+      return [nx, ny];
+    });
+  });
+  draw();
+}
+
+function scale(factor) {
+  const [cx, cy] = getCenter(geojsonData);
+  geojsonData.features.forEach(f => {
+    transformCoords(f.geometry, ([x, y]) => [cx + factor * (x - cx), cy + factor * (y - cy)]);
+  });
+  draw();
+}
+
+function download() {
+  const dataStr = 'data:application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(geojsonData, null, 2));
+  const link = document.createElement('a');
+  link.setAttribute('href', dataStr);
+  link.setAttribute('download', 'transformed_shapes.geojson');
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
 fetch('shapes.geojson')
   .then(r => r.json())
   .then(data => {
-    L.geoJSON(data, {
-      style: {
-        color: '#ff7800',
-        weight: 1,
-        fillOpacity: 0.5
-      },
-      onEachFeature: function(feature, layer) {
-        let props = feature.properties;
-        let content = Object.keys(props).map(k => `<strong>${k}:</strong> ${props[k]}`).join('<br>');
-        layer.bindPopup(content);
-      }
-    }).addTo(map);
+    geojsonData = data;
+    draw();
   });
+
+document.getElementById('up').addEventListener('click', () => translate(0, -10));
+document.getElementById('down').addEventListener('click', () => translate(0, 10));
+document.getElementById('left').addEventListener('click', () => translate(-10, 0));
+document.getElementById('right').addEventListener('click', () => translate(10, 0));
+document.getElementById('rotLeft').addEventListener('click', () => rotate(-5));
+document.getElementById('rotRight').addEventListener('click', () => rotate(5));
+document.getElementById('scaleDown').addEventListener('click', () => scale(0.9));
+document.getElementById('scaleUp').addEventListener('click', () => scale(1.1));
+document.getElementById('save').addEventListener('click', download);


### PR DESCRIPTION
## Summary
- add control panel with buttons for moving, rotating and scaling
- implement translation, rotation, and scaling for the loaded GeoJSON
- allow downloading the transformed shapes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686ef837f52c832a91fcab8ec4e74ae3